### PR TITLE
Modifications to numbered list handling

### DIFF
--- a/src/miade/annotators.py
+++ b/src/miade/annotators.py
@@ -345,8 +345,8 @@ class Annotator(ABC):
         Filters and returns a list of concepts in a numbered list in a note using a two-pointer algorithm.
 
         This filters out concepts that may not be relevant given a note that has structured list headings
-        and numbered lists within that. i.e. only return the first line of a numbered list. e.g.
-            1. CCF -
+        and numbered lists within that. i.e. only return the first concept of a numbered list. e.g.
+            1. CCF - left ventricular failure
             - had echo on 15/6
             - on diuretics
         will only return the concept CCF as it is the first item in a numbered list
@@ -386,14 +386,15 @@ class Annotator(ABC):
             if any(start <= concept.start < end for start, end in global_list_ranges):
                 # Check for partial or full overlap between concept and list item
                 if (
-                    concept.start >= item.start and concept.end <= item.end
-                ):  # or (concept.start < item.end and concept.end > item.start)
-                    # Concept overlaps with or is within the current list item
+                    concept.start >= item.start and concept.start < item.end
+                ):  # Concept starts within current list item
                     filtered_concepts.append(concept)
                     concept_idx += 1  # Move to the next concept
-                elif concept.end <= item.start:
-                    # If the concept ends before the item starts, move to the next concept
+                    item_idx += 1  # Move to the next list item i.e. only choose the first concept per item
+                elif concept.start < item.start:
+                    # If the concept starts before the item starts, move to the next concept
                     concept_idx += 1
+                    log.debug(f"Removed concept ({concept.id} | {concept.name}): within a numbered list but not the first concept in the list item")
                 else:
                     # Otherwise, move to the next list item
                     item_idx += 1

--- a/src/miade/note.py
+++ b/src/miade/note.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Dict
 
 from .paragraph import ListItem, NumberedList, Paragraph, ParagraphType
 
-
 log = logging.getLogger(__name__)
 
 
@@ -194,6 +193,12 @@ class Note(object):
         """
         merged_paragraphs = []
         skip_next = False
+        
+        def isin_numbered_list(start: int, end: int) -> bool:
+            for numbered_list in self.numbered_lists:
+                if start >= numbered_list.list_start and end <= numbered_list.list_end:
+                    return True
+            return False
 
         for i in range(len(self.paragraphs) - 1):
             if skip_next:
@@ -205,13 +210,15 @@ class Note(object):
             next_paragraph = self.paragraphs[i + 1]
 
             # Check if current paragraph has an empty body and is not of type prose
-            if current_paragraph.body == "" and current_paragraph.type != ParagraphType.prose:
+            # or there is a numbered list spanning the current and next paragraph
+            if ((current_paragraph.body == "" and current_paragraph.type != ParagraphType.prose) or
+                isin_numbered_list(current_paragraph.end, next_paragraph.start)):
                 # Check if the next paragraph is of type prose
                 if next_paragraph.type == ParagraphType.prose:
-                    # Create a new Paragraph with merged content and type prose
+                    # Create a new Paragraph with merged content and type of first paragraph
                     merged_paragraph = Paragraph(
                         heading=current_paragraph.heading,
-                        body=next_paragraph.heading,
+                        body=current_paragraph.body + '\n' + next_paragraph.heading,
                         type=current_paragraph.type,
                         start=current_paragraph.start,
                         end=next_paragraph.end,

--- a/src/miade/note.py
+++ b/src/miade/note.py
@@ -193,7 +193,7 @@ class Note(object):
         """
         merged_paragraphs = []
         skip_next = False
-        
+
         def isin_numbered_list(start: int, end: int) -> bool:
             for numbered_list in self.numbered_lists:
                 if start >= numbered_list.list_start and end <= numbered_list.list_end:
@@ -211,14 +211,15 @@ class Note(object):
 
             # Check if current paragraph has an empty body and is not of type prose
             # or there is a numbered list spanning the current and next paragraph
-            if ((current_paragraph.body == "" and current_paragraph.type != ParagraphType.prose) or
-                isin_numbered_list(current_paragraph.end, next_paragraph.start)):
+            if (current_paragraph.body == "" and current_paragraph.type != ParagraphType.prose) or isin_numbered_list(
+                current_paragraph.end, next_paragraph.start
+            ):
                 # Check if the next paragraph is of type prose
                 if next_paragraph.type == ParagraphType.prose:
                     # Create a new Paragraph with merged content and type of first paragraph
                     merged_paragraph = Paragraph(
                         heading=current_paragraph.heading,
-                        body=current_paragraph.body + '\n' + next_paragraph.heading,
+                        body=current_paragraph.body + ("\n" if current_paragraph.body else "") + next_paragraph.heading,
                         type=current_paragraph.type,
                         start=current_paragraph.start,
                         end=next_paragraph.end,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,6 +261,19 @@ and then here is some extra stuff that doesn't fall within lists, we want to det
 """
     )
 
+@pytest.fixture
+def test_note_numbered_list_with_blank_line():
+    return Note(
+        text="""Problems:
+1. Heart failure and tricuspid regurgitation
+
+2. Ischaemic heart disease -
+Previous MI
+3. Type 2 diabetes
+"""
+    )
+# Numbered list with blank line which should be closed by
+# detection of numbered list spanning multiple paragraphs
 
 @pytest.fixture(scope="function")
 def test_paragraph_chunking_prob_concepts() -> List[Concept]:

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -57,6 +57,20 @@ def test_numbered_list_note(test_problems_annotator, test_numbered_list_note):
         Concept(name="other section", id="correct"),
     ]
 
+def test_numbered_list_with_blank_line(test_problems_annotator, test_note_numbered_list_with_blank_line):
+    test_concepts = [
+        Concept(id="correct", name="first item", start=13, end=26),
+        Concept(id="incorrect", name="additional concept in first item", start=31, end=54),
+        Concept(id="correct", name="second item", start=59, end=82),
+        Concept(id="incorrect", name="additional concept in second item", start=85, end=96),
+        Concept(id="correct", name="third item", start=100, end=115),
+    ]
+    test_problems_annotator.preprocess(test_note_numbered_list_with_blank_line, refine=True)
+    assert test_problems_annotator.filter_concepts_in_numbered_list(test_concepts, test_note_numbered_list_with_blank_line) == [
+        Concept(name="first item", id="correct"),
+        Concept(name="second item", id="correct"),
+        Concept(name="third item", id="correct"),
+    ]
 
 def test_prob_paragraph_note(
     test_problems_annotator, test_clean_and_paragraphing_note, test_paragraph_chunking_prob_concepts


### PR DESCRIPTION
# Pull Request to fix numbered list handling

## Description

Corrects the following issues:

- Use only the first concept of each list item (previously the algorithm would use all concepts on the first line).
- Correct the bug where a problem list header is not propagated if there is no blank line under the problem list header but there is a blank line further down the list. (This has been handled by altering the merge_empty_non_prose_with_next_prose function to also merge paragraphs that are part of the same list.)
- Allows a concept to go beyond the end of a list item (e.g. if it runs onto the next line) by using only the start position of the concept to locate its position in a list item.

Fixes # 27 on notion

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Testing via inspection of paragraph and numbered list objects after handling the following example:

```
Problems:
1. Heart failure and tricuspid regurgitation

2. Ischaemic heart disease -
Previous MI
3. Type 2 diabetes
```

Formal tests have been drafted but I have been unable to run them.

## Checklist:

Before submitting your pull request, please review the following checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Additional Information:

This needs to be tested before merging.