### PR TITLE
Dependency updates for MedCAT, Pydantic, SpaCy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dynamic = ["version"]
 dependencies = [
     "medcat==1.15.2",
     # "spacy>=3.4.2, <3.5.0", # need to be compatible with latest med7 model
-    # "numpy>=1.22.0",
     "pandas>=2.0.0", # support 2.0.0
     "gensim>=4.3.0",
     "typer>=0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,15 @@ description = "A set of tools for extracting formattable data from clinical note
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "medcat==1.9.3",
-    "spacy>=3.4.2, <3.5.0", # need to be compatible with latest med7 model
-    "numpy>=1.22.0",
-    "pandas>=1.4.2", # support 2.0.0
+    "medcat==1.15.2",
+    # "spacy>=3.4.2, <3.5.0", # need to be compatible with latest med7 model
+    # "numpy>=1.22.0",
+    "pandas>=2.0.0", # support 2.0.0
     "gensim>=4.3.0",
     "typer>=0.7.0",
     'typing>=3.7.4',
     "pathlib>=1.0.1",
-    "pydantic>=1.10.0", # compatibility with spacy
+    "pydantic>=2.0.0", # compatibility with spacy
     "negspacy>=1.0.3",
     "requests>=2.32.3",
     "polars>=1.8.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://huggingface.co/kormilitzin/en_core_med7_lg/resolve/main/en_core_med7_lg-any-py3-none-any.whl
+# https://huggingface.co/kormilitzin/en_core_med7_lg/resolve/main/en_core_med7_lg-any-py3-none-any.whl

--- a/src/miade/core.py
+++ b/src/miade/core.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Dict
 from .concept import Concept, Category
 from .note import Note
 from .annotators import Annotator, ProblemsAnnotator, MedsAllergiesAnnotator  # noqa: F401
-from .dosageextractor import DosageExtractor
+from .dosageextractor import DosageExtractor, DummyDosageExtractor
 from .utils.miade_cat import MiADE_CAT
 from .utils.modelfactory import ModelFactory
 from .utils.annotatorconfig import AnnotatorConfig
@@ -85,7 +85,8 @@ class NoteProcessor:
         self.model_directory: Path = model_directory
         self.model_config_path: Path = model_config_path
         self.model_factory: ModelFactory = self._load_model_factory(custom_annotators)
-        self.dosage_extractor: DosageExtractor = DosageExtractor()
+        # self.dosage_extractor: DosageExtractor = DosageExtractor()
+        self.dosage_extractor: DosageExtractor = DummyDosageExtractor()
 
     def _load_config(self) -> Dict:
         """

--- a/src/miade/dosageextractor.py
+++ b/src/miade/dosageextractor.py
@@ -67,3 +67,17 @@ class DosageExtractor:
 
     def __call__(self, text: str, calculate: bool = True):
         return self.extract(text, calculate)
+
+
+class DummyDosageExtractor(DosageExtractor):
+    """
+    Dummy dosage extractor that returns None, until the Med7 model is rebuilt.
+
+    Consider why Drug / Dosage extraction is even considered a special case anyway.
+    """
+
+    def __init__(self):
+        pass
+
+    def extract(self, text: str, calculate: bool = True) -> Optional[Dosage]:
+        return None


### PR DESCRIPTION
- MedCAT update by 5 minor versions.
- Pydantic major version upgrade.
- Removed hard dep on Med7 to perform the above update
- Added a `DummyDosageExtractor` that returns nothing, as this feature won't be used for initial target deployment